### PR TITLE
CGI::Capture::TieSTDIN didn't seem to be working at all.

### DIFF
--- a/lib/CGI/Capture/TieSTDIN.pm
+++ b/lib/CGI/Capture/TieSTDIN.pm
@@ -19,7 +19,7 @@ sub TIEHANDLE {
 sub READ {
 	my $self   = shift;
 	my $string = $self->{string};
-	if ( !defined($string) || $$string eq '' ) {
+	if ( !defined($string) || !defined($$string) || $$string eq '' ) {
 		$_[0] = undef;
 		return 0;
 	}
@@ -34,19 +34,19 @@ sub READ {
 sub READLINE {
 	my $self   = shift;
 	my $string = $self->{string};
-	if ( !defined($string) || $$string eq '' ) {
+	if ( !defined($string) || !defined($$string) || $$string eq '' ) {
 		return undef;
 	}
 	if ( wantarray ) {
 		my @lines = split /(?<=\n)/, $$string;
-		$$string = '';
+		$$string = undef;
 		return @lines;
 	} else {
 		if ( $$string =~ s/^(.+?\n)//s ) {
 			return "$1";
 		} else {
 			my $rv = $$string;
-			$$string = '';
+			$$string = undef;
 			return $rv;
 		}
 	}

--- a/lib/CGI/Capture/TieSTDIN.pm
+++ b/lib/CGI/Capture/TieSTDIN.pm
@@ -10,21 +10,22 @@ our $VERSION = '1.16';
 
 sub TIEHANDLE {
 	my $class  = shift;
-	my $string_ref = shift;
+	my $string = shift;
 	return bless {
-		string_ref => $string_ref,
+		string => $string,
 	};
 }
 
 sub READ {
 	my $self   = shift;
-	if ( !defined($self->{string_ref}) || ${$self->{string_ref}} eq '' ) {
+	my $string = $self->{string};
+	if ( !defined($string) || $$string eq '' ) {
 		$_[0] = undef;
 		return 0;
 	}
-	my ($string, $length, $offset) = @_;
+	my (undef, $length, $offset) = @_;
 	$offset = 0		if (!defined($offset));
-	my $buffer = substr(${$self->{string_ref}}, $offset, $length, '');
+	my $buffer = substr( $$string, $offset, $length, '' );
 	my $rv     = length $buffer;
 	$_[0]      = $buffer;
 	return $rv;
@@ -32,20 +33,20 @@ sub READ {
 
 sub READLINE {
 	my $self   = shift;
-	my $string_ref = $self->{string_ref};
-	if ( !defined($string_ref) || $$string_ref eq '' ) {
+	my $string = $self->{string};
+	if ( !defined($string) || $$string eq '' ) {
 		return undef;
 	}
 	if ( wantarray ) {
-		my @lines = split /(?<=\n)/, $$string_ref;
-		$$string_ref = '';
+		my @lines = split /(?<=\n)/, $$string;
+		$$string = '';
 		return @lines;
 	} else {
-		if ( $$string_ref =~ s/^(.+?\n)//s ) {
-			return $1;
+		if ( $$string =~ s/^(.+?\n)//s ) {
+			return "$1";
 		} else {
-			my $rv = $$string_ref;
-			$$string_ref = '';
+			my $rv = $$string;
+			$$string = '';
 			return $rv;
 		}
 	}

--- a/t/05_tiestdin.t
+++ b/t/05_tiestdin.t
@@ -1,0 +1,54 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 3;
+use CGI::Capture::TieSTDIN      ();
+
+my $str_lines = "line one\nline two";
+
+my $str_chars = "abcdef";
+
+my $str_both = $str_lines . "\n" . $str_chars;
+
+tie *LINES, 'CGI::Capture::TieSTDIN', \$str_lines;
+tie *CHARS, 'CGI::Capture::TieSTDIN', \$str_chars;
+tie *BOTH,  'CGI::Capture::TieSTDIN', \$str_both;
+
+
+my @lines;
+for (1..3) {
+    my $line = <LINES>;
+    push @lines, $line;
+}
+is_deeply(\@lines,
+    ["line one\n", "line two", undef],
+    "line-based");
+
+
+my @chars;
+for (1..3) {
+    my $chars;
+    read(CHARS, $chars, 4);
+    push @chars, $chars;
+}
+is_deeply(\@chars,
+    ["abcd", "ef", undef],
+    "char-based");
+
+
+my @both;
+for (1..2) {
+    my $line = <BOTH>;
+    push @both, $line;
+}
+for (1..3) {
+    my $chars;
+    read(BOTH, $chars, 4);
+    push @both, $chars;
+}
+is_deeply(\@both,
+    ["line one\n", "line two\n",
+        "abcd", "ef", undef],
+    "both line- and char-based");


### PR DESCRIPTION
For example, when the CGI script below was used, `$cgi->{param}` ended up blank, when used in combination with CGI::Capture.

It was discovered that CGI::Capture::TieSTDIN didn't seem to be working much at all, so a new test file was created to test CGI::Capture::TieSTDIN by itself, and then some changes were made to allow those tests to pass.

```perl
#!/usr/bin/perl

use strict;
use warnings;

# The following script works properly when CGI::Capture is disabled. When these
# two lines are uncommented, however, this script says that $cgi->{param} is
# blank.
#BEGIN {unlink '/var/tmp/capture'}
#use CGI::Capture '/var/tmp/capture';

use CGI                 ();
use Data::Dumper        ();
use HTML::Entities      ();

my $cgi = CGI->new();

print $cgi->header('text/html');

if (%{$cgi->{param}}) {
    print "<pre>";
    print HTML::Entities::encode_entities(
            Data::Dumper->Dump([$cgi->{param}], ['$cgi->{param}']));
} else {
    print <<'EOF';
        This is a test.

        <p>
        <form method="post">
          <input type="text" name="this_is_a_test" value="1... 2... 3...">
          <button type="submit">Submit</button>
        </form>
EOF
}
```